### PR TITLE
Fix of using uninitialized memory 'message'.

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -79,7 +79,7 @@ int ret;
 
 char buffer[512];
 
-int message;
+int message = 0;
 int message_length;
 
 /* USER CODE END 0 */


### PR DESCRIPTION
Update main.c - Fix of using uninitialized memory 'message'.